### PR TITLE
fix 700 fonts

### DIFF
--- a/src/css/utils/fonts.css
+++ b/src/css/utils/fonts.css
@@ -28,6 +28,7 @@
 @font-face {
   font-display: swap;
   font-family: 'Montserrat';
+  font-style: normal;
   font-weight: 700;
   src: local('Montserrat'),
     url('../fonts/montserrat-v25-latin-700.woff2') format('woff2'),
@@ -37,6 +38,7 @@
 @font-face {
   font-display: swap;
   font-family: 'Montserrat';
+  font-style: italic;
   font-weight: 700;
   src: local('Montserrat'),
     url('../fonts/montserrat-v25-latin-700italic.woff2') format('woff2'),


### PR DESCRIPTION
пофиксил фонт, а то у нас все заголовки 700 ширины были италик)
Крч по поводу font-weight 400 + font-italic что оно делает текст bold, это происходит потому что у нас нет font-weight 400 italic и по этому оно тянет из 700-ки.
это баг, или не баг хз